### PR TITLE
Add customizable error pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,53 @@ This engine exposes configuration options through the [boxfile.yml](http://docs.
 ```yaml
 run.config:
   engine.config:
-    # webserver config
+    # whether to redirect http to https
     force_https: true
     
-    # rel_dir (directory to serve up)
+    # the directory to serve up
     rel_dir: public
+
+    # optional custom error pages
+    error_pages:
+      - errors: 404
+        page: errors/404/index.html
 ```
 
 ## Generic Usage
+The only configuration you need to do is to point the system to the directory containing the files to be served by the web server. This can be configured in the engine config in the boxfile with the `rel_dir` option as demonstrated above. The path should be relative to the directory the boxfile is in, and should not have a trailing slash.
 
-todo: explain how to add dev_packages, extra_steps, and cache_dirs to make a site generator work
+To redirect http traffic to https you can specify `force_https: true` as shown above. By default https is not enforced.
+
+### Custom error pages
+
+It is possible to optionally specify your own error pages for different HTTP status codes. For this you can specify `error_pages` in `engine.config` as shown above.
+
+For each error page you add to the list you can specify multiple errors by listing the error codes separated by a space, as shown below.
+
+```yaml
+error_pages:
+  - errors: 500 502 503 504
+    page: errors/500/index.html
+```
+
+### Using site generators
+If your site requires some processing, for example a compile step to turn your templates into plain html, you can still use this engine. In the explanation below [Jekyll](https://jekyllrb.com/) is used as an example.
+
+First you need to identify which packages you require. For Jekyll you need at least `ruby24-bundler` and most likely `nodejs`. You can specify these packages in the `dev_packages` setting in the boxfile. The packages will only be used in the compile step on your machine, so they will not be available in production. An example of this can be found below.
+
+After specifying the packages the last thing to do is to list the commands required to compile your site in `extra_steps` as shown below.
+
+```yaml
+run.config
+  dev_packages:
+    - ruby24-bundler
+    - nodejs
+
+deploy.config
+  extra_steps:
+    - bundle install
+    - bundle exec jekyll build
+```
 
 ## Help & Support
 This is a static engine provided by [Nanobox](http://nanobox.io). If you need help with this engine, you can reach out to us in the [#nanobox IRC channel](http://webchat.freenode.net/?channels=nanobox). If you are running into an issue with the engine, feel free to [create a new issue on this project](https://github.com/nanobox-io/nanobox-engine-elixir/issues/new).

--- a/lib/static.sh
+++ b/lib/static.sh
@@ -24,13 +24,37 @@ rel_dir() {
 	echo $(nos_validate "$(nos_payload "config_rel_dir")" "string" "public")
 }
 
+# configurable error pages
+error_pages() {
+  declare -a error_pages_list
+  if [[ "${PL_config_error_pages_type}" = "array" ]]; then
+    for ((i=0; i < PL_config_error_pages_length ; i++)); do
+      type=PL_config_error_pages_${i}_type
+      if [[ ${!type} = "map" ]]; then
+        errors=PL_config_error_pages_${i}_errors_value
+        page=PL_config_error_pages_${i}_page_value
+        if [[ -n ${!errors} && ${!page} ]]; then
+          entry="{\"errors\":\"${!errors}\",\"page\":\"${!page}\"}"
+          error_pages_list+=("${entry}")
+        fi
+      fi
+    done
+  fi
+  if [[ -z "error_pages_list[@]" ]]; then
+    echo "[]"
+  else
+    echo "[ $(nos_join ',' "${error_pages_list[@]}") ]"
+  fi
+}
+
 # Generate a payload to render the nginx conf
 nginx_conf_payload() {
   cat <<-END
 {
   "code_dir": "$(nos_code_dir)",
   "data_dir": "$(nos_data_dir)",
-  "force_https": $(force_https)
+  "force_https": $(force_https),
+  "error_pages": $(error_pages)
 }
 END
 }

--- a/templates/nginx/nginx.conf
+++ b/templates/nginx/nginx.conf
@@ -44,6 +44,14 @@ http {
             index  index.html;
         }
 
+{{#error_pages}}
+        error_page {{errors}} /{{page}};
+        location = /{{page}} {
+                root {{code_dir}};
+                internal;
+        }
+{{/error_pages}}
+
         # deny access to .htaccess files, if Apache's document root
         # concurs with nginx's one
         


### PR DESCRIPTION
Implementation originates from [nanobox-io/nanobox-engine-tolmark-gulp](https://github.com/nanobox-io/nanobox-engine-tolmark-gulp) without modifications.